### PR TITLE
Connect in TextOnly mode and "no ReceivedItems" items_handling flag

### DIFF
--- a/Archipelago/ArchipelagoInterface.js
+++ b/Archipelago/ArchipelagoInterface.js
@@ -1,4 +1,4 @@
-const { Client, ITEMS_HANDLING_FLAGS, SERVER_PACKET_TYPE, ConnectionStatus } = require('archipelago.js');
+const { Client, ITEMS_HANDLING_FLAGS, COMMON_TAGS, SERVER_PACKET_TYPE, ConnectionStatus } = require('archipelago.js');
 const { User } = require('discord.js');
 const { v4: uuid } = require('uuid');
 
@@ -7,17 +7,15 @@ class ArchipelagoInterface {
    * @param textChannel discord.js TextChannel
    * @param {string} host
    * @param {Number} port
-   * @param {string} gameName
    * @param {string} slotName
    * @param {string|null} password optional
    */
-  constructor(textChannel, host, port, gameName, slotName, password=null) {
+  constructor(textChannel, host, port, slotName, password=null) {
     this.textChannel = textChannel;
     this.messageQueue = [];
     this.players = new Map();
     this.APClient = new Client();
 
-    this.gameName = gameName;
     this.slotName = slotName;
 
     // Controls which messages should be printed to the channel
@@ -30,9 +28,10 @@ class ArchipelagoInterface {
       hostname: host,
       port,
       uuid: uuid(),
-      game: gameName,
+      game: "", // Copying the behavior of the official Text client
       name: slotName,
-      items_handling: ITEMS_HANDLING_FLAGS.REMOTE_ALL,
+      tags: [COMMON_TAGS.TEXT_ONLY],
+      items_handling: ITEMS_HANDLING_FLAGS.LOCAL_ONLY,
     };
 
     this.APClient.connect(connectionInfo).then(() => {

--- a/Archipelago/ArchipelagoInterface.js
+++ b/Archipelago/ArchipelagoInterface.js
@@ -30,6 +30,7 @@ class ArchipelagoInterface {
       uuid: uuid(),
       game: "", // Copying the behavior of the official Text client
       name: slotName,
+      password: password,
       tags: [COMMON_TAGS.TEXT_ONLY],
       items_handling: ITEMS_HANDLING_FLAGS.LOCAL_ONLY,
     };

--- a/slashCommandCategories/archipelago.js
+++ b/slashCommandCategories/archipelago.js
@@ -18,10 +18,6 @@ module.exports = {
           .setDescription('Port number your game is hosted on')
           .setRequired(true))
         .addStringOption((opt) => opt
-          .setName('game-name')
-          .setDescription('Name of the game to connect as a client of')
-          .setRequired(true))
-        .addStringOption((opt) => opt
           .setName('slot-name')
           .setDescription('`name` field in your settings file')
           .setRequired(true))
@@ -32,7 +28,6 @@ module.exports = {
       async execute(interaction) {
         const serverAddress = interaction.options.getString('server-address');
         const port = interaction.options.getNumber('port');
-        const gameName = interaction.options.getString('game-name');
         const slotName = interaction.options.getString('slot-name');
         const password = interaction.options.getString('password', false) ?? null;
 
@@ -46,7 +41,7 @@ module.exports = {
 
         // Establish a connection to the Archipelago game
         const APInterface = new ArchipelagoInterface(interaction.channel, serverAddress, port,
-          gameName, slotName, password);
+          slotName, password);
 
         // Check if the connection was successful every half second for five seconds
         for (let i=0; i<10; ++i){
@@ -56,7 +51,7 @@ module.exports = {
           if (APInterface.APClient.status === 'Connected') {
             interaction.client.tempData.apInterfaces.set(interaction.channel.id, APInterface);
             await interaction.reply({
-              content: `Connected to ${serverAddress} using game ${gameName} with slot ${slotName}.`,
+              content: `Connected to ${serverAddress} with slot ${slotName}.`,
               ephemeral: false,
             });
 


### PR DESCRIPTION
Passing the TextOnly tag just like the official Text client, allows to skip the game name validation. That way we can remove the game_name field.

Connecting with `items_handling` in "local only" mode means the server will not send us ReceivedItems messages, which we do not handle anyway. (The Text client still chooses to receive those, but only to allow doing the `/release` command which we can't do)

See text client code: https://github.com/ArchipelagoMW/Archipelago/blob/main/CommonClient.py#L891

Also this fixes a bug where the password wasn't passed to Archipelago.

![image](https://github.com/LegendaryLinux/ArchipelaBot/assets/4723472/7a8ac711-7171-4299-b5ba-b5b3da7e754a)
![image](https://github.com/LegendaryLinux/ArchipelaBot/assets/4723472/d07ffdf5-3097-4e7d-b7f6-561f8d7ac3a0)
