### PR TITLE
Handle aliases for all messages, and add commands to show only messages with a known alias

### DIFF
--- a/Archipelago/ArchipelagoInterface.js
+++ b/Archipelago/ArchipelagoInterface.js
@@ -25,6 +25,7 @@ class ArchipelagoInterface {
     this.showItems = true;
     this.showProgression = true;
     this.showChat = true;
+    this.showNonAliased = true;
 
     const connectionInfo = {
       hostname: host,
@@ -63,17 +64,14 @@ class ArchipelagoInterface {
     let messages = [];
 
     for (let message of this.messageQueue) {
+      // Replace player names with Discord User objects
+      let hasKnownAlias = this.handleAliases(message)
+      if (!this.showNonAliased && !hasKnownAlias) { continue; }
+
       switch(message.type) {
         case 'hint':
         // Ignore hint messages if they should not be displayed
           if (!this.showHints) { continue; }
-
-          // Replace player names with Discord User objects
-          for (let alias of this.players.keys()) {
-            if (message.content.includes(alias)) {
-              message.content = message.content.replace(alias, this.players.get(alias));
-            }
-          }
           break;
 
         case 'item':
@@ -209,6 +207,23 @@ class ArchipelagoInterface {
     clearTimeout(this.queueTimeout);
     this.APClient.disconnect();
   };
+
+  /**
+   * Replaces all known aliases by their Discord User objects in the passed message
+   * @param {string} alias
+   * @returns {boolean} Whether an alias was found
+   */
+  handleAliases = (message) => {
+    let hasKnownAlias = false
+    for (let alias of this.players.keys()) {
+      if (message.content.includes(alias)) {
+        message.content = message.content.replace(alias, this.players.get(alias));
+        hasKnownAlias = true
+      }
+    }
+    return hasKnownAlias;
+  }
+
 }
 
 module.exports = ArchipelagoInterface;

--- a/slashCommandCategories/archipelago.js
+++ b/slashCommandCategories/archipelago.js
@@ -283,5 +283,41 @@ module.exports = {
         return interaction.reply('Hiding all item messages.');
       },
     },
+    {
+      commandBuilder: new SlashCommandBuilder()
+        .setName('ap-show-non-associated-aliases')
+        .setDescription('Stop filtering messages without an associated alias')
+        .setDMPermission(false),
+      async execute(interaction) {
+        // Notify the user if there is no game being monitored in the current text channel
+        if (!interaction.client.tempData.apInterfaces.has(interaction.channel.id)) {
+          return interaction.reply({
+            content: 'There is no Archipelago game being monitored in this channel.',
+            ephemeral: true,
+          });
+        }
+
+        interaction.client.tempData.apInterfaces.get(interaction.channel.id).showNonAliased = true;
+        return interaction.reply('Stopped filtering messages based on their alias.');
+      },
+    },
+    {
+      commandBuilder: new SlashCommandBuilder()
+        .setName('ap-hide-non-associated-aliases')
+        .setDescription('Hide all messages that are not relevant to aliases set with /ap-set-alias')
+        .setDMPermission(false),
+      async execute(interaction) {
+        // Notify the user if there is no game being monitored in the current text channel
+        if (!interaction.client.tempData.apInterfaces.has(interaction.channel.id)) {
+          return interaction.reply({
+            content: 'There is no Archipelago game being monitored in this channel.',
+            ephemeral: true,
+          });
+        }
+
+        interaction.client.tempData.apInterfaces.get(interaction.channel.id).showNonAliased = false;
+        return interaction.reply('Only showing messages relevant to aliases set with `/ap-set-alias`.');
+      },
+    },
   ],
 };


### PR DESCRIPTION
Useful to filter messages to only show the ones you care about.

![image](https://github.com/LegendaryLinux/ArchipelaBot/assets/4723472/3f03aef6-7753-49c7-b90a-80f8e1bffad9)
